### PR TITLE
Allow duplicated or empty names

### DIFF
--- a/blogger2pelican.py
+++ b/blogger2pelican.py
@@ -168,7 +168,7 @@ def save_post(directory, post):
         os.makedirs(os.path.dirname(post_path))
 
     if os.path.exists(post_path):
-        raise IOError("File '{}' already exists".format(post_path))
+        post_path = post_path[:-3] + '-duplicated-' + str(uuid.uuid4())[:8] + '.md'
 
     with open(post_path, 'wb') as post_file:
         data = make_post(post)

--- a/blogger2pelican.py
+++ b/blogger2pelican.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import six
+import uuid
 
 try:
     from urllib.parse import urlparse
@@ -206,7 +207,7 @@ def parse_entry(entry):
     result['published'] = simplify_datetime(result['published'])
     result['updated'] = u''.join(entry.select('a:updated/text()').extract())
     result['updated'] = simplify_datetime(result['updated'])
-    result['title'] = u''.join(entry.select('a:title/text()').extract())
+    result['title'] = u''.join(entry.select('a:title/text()').extract()) or 'untitled-' + str(uuid.uuid4())[:8]
 
     content = u''.join(entry.select('a:content/text()').extract())
     post2md = Post2MD(content)


### PR DESCRIPTION
Hello, I decided to add some small improvements to avoid some exceptions when running the script, mainly allowing the conversion of untitled posts or post containing duplicated names. I needed to do this changes in order to allow the script execution to finish.

I used this script today with an XML exported also today and it still works, although I haven't checked that all the information is there. Thanks for creating it, it was very useful. :-)